### PR TITLE
🔧 Fix SCSS @import deprecation warnings

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
-@import "tailwindcss";
-@import './styles/variables.scss';
+@use "tailwindcss";
+@use './styles/variables' as vars;
 
 /* Reset and base styles */
 * {
@@ -11,16 +11,16 @@ html, body {
   height: 100%;
   margin: 0;
   padding: 0;
-  font-family: $font-family-base;
-  font-size: $font-size-base;
+  font-family: vars.$font-family-base;
+  font-size: vars.$font-size-base;
   line-height: 1.5;
-  color: $gray-900;
-  background-color: $gray-50;
+  color: vars.$gray-900;
+  background-color: vars.$gray-50;
 }
 
 body {
   margin: 0;
-  font-family: $font-family-base;
+  font-family: vars.$font-family-base;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -29,7 +29,7 @@ body {
 .container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 $spacing-md;
+  padding: 0 vars.$spacing-md;
 }
 
 .text-center {
@@ -44,20 +44,20 @@ body {
   text-align: right;
 }
 
-.mt-1 { margin-top: $spacing-xs; }
-.mt-2 { margin-top: $spacing-sm; }
-.mt-3 { margin-top: $spacing-md; }
-.mt-4 { margin-top: $spacing-lg; }
-.mt-5 { margin-top: $spacing-xl; }
+.mt-1 { margin-top: vars.$spacing-xs; }
+.mt-2 { margin-top: vars.$spacing-sm; }
+.mt-3 { margin-top: vars.$spacing-md; }
+.mt-4 { margin-top: vars.$spacing-lg; }
+.mt-5 { margin-top: vars.$spacing-xl; }
 
-.mb-1 { margin-bottom: $spacing-xs; }
-.mb-2 { margin-bottom: $spacing-sm; }
-.mb-3 { margin-bottom: $spacing-md; }
-.mb-4 { margin-bottom: $spacing-lg; }
-.mb-5 { margin-bottom: $spacing-xl; }
+.mb-1 { margin-bottom: vars.$spacing-xs; }
+.mb-2 { margin-bottom: vars.$spacing-sm; }
+.mb-3 { margin-bottom: vars.$spacing-md; }
+.mb-4 { margin-bottom: vars.$spacing-lg; }
+.mb-5 { margin-bottom: vars.$spacing-xl; }
 
-.p-1 { padding: $spacing-xs; }
-.p-2 { padding: $spacing-sm; }
-.p-3 { padding: $spacing-md; }
-.p-4 { padding: $spacing-lg; }
-.p-5 { padding: $spacing-xl; }
+.p-1 { padding: vars.$spacing-xs; }
+.p-2 { padding: vars.$spacing-sm; }
+.p-3 { padding: vars.$spacing-md; }
+.p-4 { padding: vars.$spacing-lg; }
+.p-5 { padding: vars.$spacing-xl; }


### PR DESCRIPTION
## Summary
Resolves SCSS deprecation warnings that would break in Dart Sass 3.0.0 by migrating from deprecated `@import` to modern `@use` syntax.

## Changes Made
- **Fixed deprecation warnings**: Replaced `@import` with `@use` syntax in `src/styles.scss`
- **Updated variable namespace**: Changed all variable references from `$var` to `vars.$var`
- **Maintained functionality**: All styling and behavior preserved

## Files Changed
- `src/styles.scss`: Migrated from @import to @use syntax

## Validation
- ✅ Build completes without SCSS deprecation warnings
- ✅ All 117 tests pass
- ✅ Lint checks pass
- ✅ Visual appearance unchanged

## Addresses Issue #30
This PR completes **Phase 1** of issue #30 (Critical Priority: SCSS deprecation warnings).

The style budget warning for `todo-item.component.scss` remains and will be addressed in a future PR.

🤖 Generated with [Claude Code](https://claude.ai/code)